### PR TITLE
Fix: add error handling after building Kustomizations

### DIFF
--- a/cmd/azuredevops.go
+++ b/cmd/azuredevops.go
@@ -64,6 +64,10 @@ func runAzuredevopsCommand(cmd *cobra.Command, args []string) {
 	}
 
 	oldKustomization, newKustomization, err := kustomize.BuildKustomizations(kustomizeExecutable, pathToOldVersion, pathToNewVersion)
+	if err != nil {
+		utils.Logger.Error("Building Kustomizations failed.", zap.Error(err))
+		os.Exit(1)
+	}
 
 	// Create a diff of both Kustomizations.
 	diffs, err := k8s.CreateDiffForManifestFiles(oldKustomization, newKustomization)

--- a/cmd/inline.go
+++ b/cmd/inline.go
@@ -39,6 +39,10 @@ func runInlineCommand(cmd *cobra.Command, args []string) {
 	}
 
 	oldKustomization, newKustomization, err := kustomize.BuildKustomizations(kustomizeExecutable, pathToOldVersion, pathToNewVersion)
+	if err != nil {
+		utils.Logger.Error("Building Kustomizations failed.", zap.Error(err))
+		os.Exit(1)
+	}
 
 	// Create a diff of both Kustomizations.
 	diffs, err := k8s.CreateDiffForManifestFiles(oldKustomization, newKustomization)


### PR DESCRIPTION
Currently, after building Kustomizations from the input paths, no error handling is applied. The PR adds this missing error handling.