### PR TITLE
Fix: add error handling to Azure DevOps client

### DIFF
--- a/azuredevops/client.go
+++ b/azuredevops/client.go
@@ -58,7 +58,7 @@ func CreatePullRequestComment(azureDevOpsParameters *AzureDevOpsParameters, cont
 
 	responseValue, err := httpClient.CreateThread(ctx, createThreadRequest)
 	if err != nil {
-		errors.Join(errors.New("Creating new comment thread on pull request failed."), err)
+		return errors.Join(errors.New("Creating new comment thread on pull request failed."), err)
 	}
 
 	utils.Logger.Info("Created comment thread successfully.", zap.Int("threadId", *responseValue.Id))


### PR DESCRIPTION
If creating the PR comment via the Azure DevOps client fails, the error handling is currently incomplete. The PR adds a missing return statement.