### PR TITLE
Add multi-line string to tests

### DIFF
--- a/kubernetes/manifest_differ_test.go
+++ b/kubernetes/manifest_differ_test.go
@@ -38,7 +38,9 @@ func TestCreateDiffForManifestFilesReturnsCorrectResult(t *testing.T) {
    namespace: my-namespace
  spec:
 -  type: ClusterIP
-+  type: NodePort`
++  type: NodePort
++  sessionAffinity: |
++    ClientIp`
 
 	if !diffsContainExpectedDiff(diffs, expectedDiff1) || !diffsContainExpectedDiff(diffs, expectedDiff2) {
 		t.Fatal("Diff should show changes if manifest was altered.")

--- a/kubernetes/manifest_differ_test.go
+++ b/kubernetes/manifest_differ_test.go
@@ -14,7 +14,7 @@ func TestCreateDiffForManifestFilesReturnsCorrectResult(t *testing.T) {
 		"---\n" +
 		"apiVersion: v1\nkind: Service\nmetadata:\n  name: backend-headless\n  namespace: my-namespace\nspec:\n  clusterIP: None" +
 		"---\n" +
-		"apiVersion: v1\nkind: Service\nmetadata:\n  name: backend\n  namespace: my-namespace\nspec:\n  type: NodePort"
+		"apiVersion: v1\nkind: Service\nmetadata:\n  name: backend\n  namespace: my-namespace\nspec:\n  type: NodePort\n  sessionAffinity: |\n    ClientIp"
 
 	diffs, err := CreateDiffForManifestFiles(&oldManifest, &newManifest)
 


### PR DESCRIPTION
The tests currently lack a YAML multi-line string and there have been some issues which could be related to those. The change adds one to the tests just to make sure it's covered.