### PR TITLE
Feat: Don't comment if there is no diff

### DIFF
--- a/cmd/azuredevops.go
+++ b/cmd/azuredevops.go
@@ -80,6 +80,11 @@ func runAzuredevopsCommand(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	if len(diffs) == 0 {
+		utils.Logger.Debug("No diff found, exiting.")
+		os.Exit(0)
+	}
+
 	// Prepare diff slices to process depending on the command flags.
 	var diffSlices [][]k8s.ManifestDiff
 	if azureDevOpsCommandFlags.CommentPerResource {


### PR DESCRIPTION
Hey, thanks for the nice tool =) 

I noticed Azure DevOps comments are created even without any diff. 
This PR prevents that. 

Is this the intended behavior?
If so, we could add an optional argument to the `kustomize azuredevops` command instead.